### PR TITLE
bower: default location for bower.json

### DIFF
--- a/invenio_assets/version.py
+++ b/invenio_assets/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.1.0.dev20150000"
+__version__ = "1.0.0.dev20150000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,9 @@
 
 from __future__ import absolute_import, print_function
 
+import shutil
+import tempfile
+
 import pytest
 from flask import Flask
 from flask_cli import FlaskCLI, ScriptInfo
@@ -42,9 +45,15 @@ def app():
 
 
 @pytest.fixture()
-def script_info():
+def script_info(request):
     """Get ScriptInfo object for testing CLI."""
-    app = Flask(__name__)
+    instance_path = tempfile.mkdtemp()
+    app = Flask(__name__, instance_path=instance_path)
     FlaskCLI(app)
     InvenioAssets(app)
+
+    def teardown():
+        shutil.rmtree(instance_path)
+
+    request.addfinalizer(teardown)
     return ScriptInfo(create_app=lambda info: app)

--- a/tests/test_invenio_assets.py
+++ b/tests/test_invenio_assets.py
@@ -61,6 +61,14 @@ def test_init_post(app):
     assert 'COLLECT_STATIC_ROOT' in app.config
 
 
+def test_init_cli(app):
+    """Test cli registration."""
+    assets = InvenioAssets(app)
+    assert len(app.cli.commands) == 0
+    assets.init_cli(app.cli)
+    assert len(app.cli.commands) == 3
+
+
 def test_assets_usage(app):
     """Test assets usage."""
     class Ext(object):


### PR DESCRIPTION
* Changes bower command to always write a file which by default is
  the application's instance folder. (closes #1)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>