### PR TITLE
npm: semantic version fix

### DIFF
--- a/invenio_assets/cli.py
+++ b/invenio_assets/cli.py
@@ -29,14 +29,13 @@ from __future__ import absolute_import, print_function
 import json
 import logging
 import os
-import re
 
 import click
 from flask import current_app
 from flask_cli import with_appcontext
 from pkg_resources import DistributionNotFound, get_distribution
 
-from .npm import extract_deps
+from .npm import extract_deps, make_semver
 from .proxy import current_assets
 
 
@@ -69,7 +68,7 @@ def npm(package_json, output_file):
 
     output = {
         "name": current_app.name,
-        "version": re.sub('[a-z]', '', version),
+        "version": make_semver(version) if version else version,
         "dependencies": {},
     }
 

--- a/invenio_assets/npm.py
+++ b/invenio_assets/npm.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 
 import semver
 from flask_assets import Bundle as BundleBase
+from pkg_resources import parse_version
 
 
 class NpmBundle(BundleBase):
@@ -79,3 +80,38 @@ def extract_deps(bundles, log=None):
                 .format(repr(package), versions, repr(deps[package])))
 
     return deps
+
+
+def make_semver(version_str):
+    """Make a semantic version from Python PEP440 version.
+
+    Semantic versions does not handle post-releases.
+    """
+    v = parse_version(version_str)
+
+    major = v._version.release[0]
+    try:
+        minor = v._version.release[1]
+    except IndexError:
+        minor = 0
+    try:
+        patch = v._version.release[2]
+    except IndexError:
+        patch = 0
+
+    prerelease = []
+    if v._version.pre:
+        prerelease.append("".join(str(x) for x in v._version.pre))
+    if v._version.dev:
+        prerelease.append("".join(str(x) for x in v._version.dev))
+    prerelease = ".".join(prerelease)
+
+    # Create semver
+    version = "{0}.{1}.{2}".format(major, minor, patch)
+
+    if prerelease:
+        version += "-{0}".format(prerelease)
+    if v.local:
+        version += "+{0}".format(v.local)
+
+    return version

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -34,7 +34,7 @@ from flask_assets import Bundle
 
 from invenio_assets import NpmBundle
 from invenio_assets.cli import npm
-from invenio_assets.npm import extract_deps
+from invenio_assets.npm import extract_deps, make_semver
 
 
 def test_init():
@@ -127,3 +127,30 @@ def test_extract_deps():
     }
 
     assert expected == extract_deps([bundle])
+
+
+def test_make_semver():
+    """Test make semver."""
+    tests = [
+        ('1.0.dev456', '1.0.0-dev456'),
+        ('1.0a1', '1.0.0-a1'),
+        ('1.0a2.dev456', '1.0.0-a2.dev456'),
+        ('1.0a12.dev456', '1.0.0-a12.dev456'),
+        ('1.0a12', '1.0.0-a12'),
+        ('1.0b1.dev456', '1.0.0-b1.dev456'),
+        ('1.0b2', '1.0.0-b2'),
+        ('1.0b2.post345.dev456', '1.0.0-b2.dev456'),
+        ('1.0b2.post345', '1.0.0-b2'),
+        ('1.0rc1.dev456', '1.0.0-rc1.dev456'),
+        ('1.0rc1', '1.0.0-rc1'),
+        ('1.0', '1.0.0'),
+        ('1', '1.0.0'),
+        ('1.0+abc.5', '1.0.0+abc.5'),
+        ('1.0+abc.7', '1.0.0+abc.7'),
+        ('1.0+5', '1.0.0+5'),
+        ('1.0.post456.dev34', '1.0.0-dev34'),
+        ('1.0.post456', '1.0.0'),
+        ('1.1.dev1', '1.1.0-dev1'),
+    ]
+    for pyver, expected_semver in tests:
+        assert make_semver(pyver) == expected_semver


### PR DESCRIPTION
* Fixes generated npm package version by creating a semantic version
  from a Python PEP440 version. (closes #13)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>