### PR TITLE
docs: fixed module name

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,3 +34,4 @@ Media assets management for Invenio.
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Yoan Blanc <yoan@dosimple.ch>
+- Ivan Masar <helix84@centrum.sk>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ User's Guide
 ------------
 
 This part of the documentation will show you how to get started in using
-Invenio-Base.
+Invenio-Assets.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The same error is also in other modules - there's probably a template somewhere that needs to be fixed.