### PR TITLE
installation: support for Flask-Assets>=0.12

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/invenio_assets/cli.py
+++ b/invenio_assets/cli.py
@@ -52,26 +52,12 @@ from pkg_resources import DistributionNotFound, get_distribution
 from .npm import extract_deps, make_semver
 from .proxies import current_assets
 
-__all__ = ('assets', 'collect', 'npm', )
+__all__ = ('collect', 'npm', )
 
 
 #
 # Assets commands
 #
-def _webassets_cmd(cmd):
-    """Helper to run a webassets command.
-
-    :param cmd: Command name.
-    """
-    from webassets.script import CommandLineEnvironment
-    logger = logging.getLogger('webassets')
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(logging.DEBUG)
-    cmdenv = CommandLineEnvironment(current_app.jinja_env.assets_environment,
-                                    logger)
-    getattr(cmdenv, cmd)()
-
-
 @click.command()
 @click.option('-i', '--package-json', help='base input file', default=None,
               type=click.File('r'))
@@ -111,32 +97,6 @@ def npm(package_json, output_file):
     click.echo('Writing {0}'.format(output_file.name))
     json.dump(output, output_file, indent=4)
     output_file.close()
-
-
-@click.group()
-def assets():
-    """Web assets commands."""
-
-
-@assets.command()
-@with_appcontext
-def build():
-    """Build bundles."""
-    _webassets_cmd('build')
-
-
-@assets.command()
-@with_appcontext
-def clean():
-    """Clean bundles."""
-    _webassets_cmd('clean')
-
-
-@assets.command()
-@with_appcontext
-def watch():
-    """Watch bundles for file changes."""
-    _webassets_cmd('watch')
 
 
 #

--- a/invenio_assets/ext.py
+++ b/invenio_assets/ext.py
@@ -30,9 +30,6 @@ import pkg_resources
 from flask_assets import Environment
 from flask_collect import Collect
 
-from .cli import assets as assets_cmd
-from .cli import collect, npm
-
 __all__ = ('InvenioAssets', )
 
 

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.11',
-    'Flask-Assets>=0.11,<0.12',  # 0.12 will install Flask command 'assets'
+    'Flask-Assets>=0.12',
     'Flask-Collect==1.2.2',
     'node-semver>=0.1.1',
-    'webassets>=0.11.1'
+    'webassets>=0.12',
 ]
 
 packages = find_packages()
@@ -91,7 +91,6 @@ setup(
     platforms='any',
     entry_points={
         'flask.commands': [
-            'assets = invenio_assets.cli:assets',
             'collect = invenio_assets.cli:collect',
             'npm = invenio_assets.cli:npm',
         ],

--- a/tests/test_invenio_assets_cli.py
+++ b/tests/test_invenio_assets_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,8 +30,9 @@ from __future__ import absolute_import, print_function
 import os
 
 from click.testing import CliRunner
+from flask_assets import assets
 
-from invenio_assets.cli import assets, collect
+from invenio_assets.cli import collect
 
 
 def test_invenio_assets_assets(script_info_assets):


### PR DESCRIPTION
* Removes custom implementation of `assets` group and relies on
  Flask-Assets>=0.12.  (closes #36) (closes #37)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>