### PR TITLE
cli: addition of pinned option in npm

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,12 +27,13 @@ Authors
 
 Media assets management for Invenio.
 
+- Alexander Ioannidis <a.ioannidis@cern.ch>
+- Alizee Pace <alizee.pace@gmail.com>
 - Harris Tzovanakis <me@drjova.com>
+- Ivan Masár <helix84@centrum.sk>
 - Javier Delgado <javier.delgado.fernandez@cern.ch>
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Yoan Blanc <yoan@dosimple.ch>
-- Ivan Masár <helix84@centrum.sk>
-- Alizee Pace <alizee.pace@gmail.com>

--- a/invenio_assets/cli.py
+++ b/invenio_assets/cli.py
@@ -41,7 +41,6 @@ For detailed information about installed command you can execute:
 from __future__ import absolute_import, print_function
 
 import json
-import logging
 import os
 
 import click
@@ -63,8 +62,10 @@ __all__ = ('collect', 'npm', )
               type=click.File('r'))
 @click.option('-o', '--output-file', help='write package.json to output file',
               metavar='FILENAME', type=click.File('w'))
+@click.option('-p', '--pinned-file', help='pinned versions package file',
+              default=None, type=click.File('r'))
 @with_appcontext
-def npm(package_json, output_file):
+def npm(package_json, output_file, pinned_file):
     """Generate a package.json file."""
     try:
         version = get_distribution(current_app.name).version
@@ -85,6 +86,11 @@ def npm(package_json, output_file):
     deps = extract_deps(current_app.extensions['invenio-assets'].env,
                         click.echo)
     output['dependencies'].update(deps)
+
+    # Load pinned dependencies
+    if pinned_file:
+        output['dependencies'].update(
+            json.load(pinned_file).get('dependencies', {}))
 
     # Write to static folder if output file is not specified
     if output_file is None:

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -113,6 +113,25 @@ def test_cli(script_info):
         with open('package.json') as f:
             package_json = json.loads(f.read())
         assert package_json == expected
+    del expected['dependencies']['font-awesome']
+
+    # Test pinned file.
+    pinned_deps = {'bootstrap': '2.9.9'}
+    expected['dependencies'].update(pinned_deps)
+    with runner.isolated_filesystem():
+        with open('pinned.json', 'wt') as f:
+            f.write(json.dumps({'dependencies': pinned_deps}))
+
+        result = runner.invoke(
+            npm, ['-p', 'pinned.json', '-o', 'package.json'], obj=script_info)
+        assert result.exit_code == 0
+
+        filepath = os.path.join('package.json')
+        assert os.path.exists(filepath)
+
+        with open('package.json') as f:
+            package_json = json.loads(f.read())
+        assert package_json == expected
 
 
 def test_extract_deps():


### PR DESCRIPTION
* Adds a `--pinned-file` option in npm which contains pinned
  versions of npm packages.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>