### PR TITLE
filters: ignore missing translations

### DIFF
--- a/invenio_assets/filters.py
+++ b/invenio_assets/filters.py
@@ -106,7 +106,7 @@ class CleanCSSFilter(ExternalTool):
 
 
 _re_language_code = re.compile(
-    r'"Language: (?P<language_code>[A-Za-z_]{2,}(_[A-Za-z]{2,})?)\n"'
+    r'"Language: (?P<language_code>[A-Za-z_]{2,}(_[A-Za-z]{2,})?)\\n"'
 )
 """Match language code group in PO file."""
 
@@ -141,6 +141,6 @@ class AngularGettextFilter(Filter):
         out.write('gettextCatalog.setStrings("{0}", '.format(language_code))
         out.write(json.dumps({
             key: value.string for key, value in catalog._messages.items()
-            if key
+            if key and value.string
         }))
         out.write(');')

--- a/tests/test_invenio_assets_filters.py
+++ b/tests/test_invenio_assets_filters.py
@@ -99,21 +99,24 @@ class TestInvenioAssetsAngularGettextFilter(TempEnvironmentHelper):
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-assets 1.0.0.dev20161014\n"
-"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2016-10-14 15:18+0200\n"
-"PO-Revision-Date: 2016-10-14 15:37+0200\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: fr\n"
-"Language-Team: French (http://www.transifex.com/inveniosoftware/)\n"
-"Plural-Forms: nplurals=2; plural=(n > 1)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Project-Id-Version: invenio-assets 1.0.0.dev20161014\\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\\n"
+"POT-Creation-Date: 2016-10-14 15:18+0200\\n"
+"PO-Revision-Date: 2016-10-14 15:37+0200\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language: fr\\n"
+"Language-Team: French (http://www.transifex.com/inveniosoftware/)\\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: Babel 2.3.4\\n"
 
 msgid "Error:"
 msgstr "Erreur:"
+
+msgid "Missing"
+msgstr ""
         """
     }
 
@@ -132,3 +135,4 @@ msgstr "Erreur:"
             assert '"fr"' in catalog
             assert 'testInvenioAssets' in catalog
             assert 'Erreur' in catalog
+            assert 'Missing' not in catalog


### PR DESCRIPTION
- Removes missing translations before building bundle.
- Fixes new line escaping.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
