### PR TITLE
travis: npm global installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[all]"
   - "npm update"
-  - "npm install --silent clean-css clean-css-cli requirejs"
+  - "npm install --global --silent clean-css clean-css-cli requirejs"
 
 script:
   - "./run-tests.sh"


### PR DESCRIPTION
I previously sent an empty commit to check if the build failure of https://github.com/inveniosoftware/invenio-assets/pull/73 was already there, and it is: https://travis-ci.org/inveniosoftware/invenio-assets/jobs/278404145

Now I sent a very simple commit that installs the NPM dependencies globally, and it works: https://travis-ci.org/inveniosoftware/invenio-assets/builds/278405627. In fact, I don't really understand how it could have worked before, given what I read in https://github.com/requirejs/r.js/issues/488.

Is my fix really correct, or am I missing something?