### PR TITLE
cli: add deprecation warning for the AMD builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'flask.commands': [
             'collect = invenio_assets.cli:collect',
             'npm = invenio_assets.cli:npm',
+            'assets = invenio_assets.cli:assets'
         ],
         'invenio_base.apps': [
             'invenio_assets = invenio_assets:InvenioAssets',


### PR DESCRIPTION
* Overwrittes the Flask-Assets command to add the deprecation
  warning (closes #85).