### PR TITLE
package.json: pin less-loader version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.2.4 (released 2020-06-24)
+
+* Pins less-loader to version 6.1.0.
+  See https://github.com/inveniosoftware/invenio-assets/issues/130.
+
 Version 1.2.3 (released 2020-05-27)
 
 * Fixes an alias issue with jQuery.

--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -44,7 +44,7 @@
     "friendly-errors-webpack-plugin": "^1.7.0",
     "function-bind": "^1.1.1",
     "less": "^2.7.3",
-    "less-loader": "^6.1.0",
+    "less-loader": "6.1.0",
     "mini-css-extract-plugin": "0.5.0",
     "node-sass": "^4.11.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",

--- a/invenio_assets/version.py
+++ b/invenio_assets/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_assets.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'


### PR DESCRIPTION
`less-loader` version `6.1.2` breaks the assets build, giving an error regarding `../../theme.config$` alias resolution.

See issue #130 