### PR TITLE
Bump eslint-config-react-app, fixes #142

### DIFF
--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -26,7 +26,7 @@
     "css-loader": "^4.2.1",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "6.11.0",
-    "eslint-config-react-app": "^5.2.1",
+    "eslint-config-react-app": "^6.0.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "^4.0.2",


### PR DESCRIPTION
This is an attempt to fix the problem described in #142. Summary:

* There seems to be a problem with the dependency resolution during `npm install`.
* It seems the culprit is `eslint-config-react-app@"^5.2.1"`, which transitively depends on `eslint@"^5.0.0 || ^6.0.0"`, while `eslint@"^7.7.0"` was already specified as a dependency already.
* Bumping to `eslint-config-react-app@"^6.0.0"` seems to fix the problem.