### PR TITLE
Webpack: Resolve `assets watch` not recompiling

### DIFF
--- a/invenio_assets/assets/build/webpack.config.js
+++ b/invenio_assets/assets/build/webpack.config.js
@@ -3,6 +3,7 @@
  * Copyright (C) 2017-2018 CERN.
  * Copyright (C) 2022-2023 Graz University of Technology.
  * Copyright (C) 2023      TU Wien.
+ * Copyright (C) 2024      KTH Royal Institute of Technology.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
@@ -252,6 +253,7 @@ var webpackConfig = {
   watchOptions: {
     followSymlinks: true,
   },
+  cache: false,
 };
 
 if (process.env.npm_config_report) {

--- a/invenio_assets/assets/build/webpack.config.js
+++ b/invenio_assets/assets/build/webpack.config.js
@@ -10,7 +10,6 @@
  */
 
 const BundleTracker = require("webpack-bundle-tracker");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const ESLintPlugin = require("eslint-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -19,7 +18,7 @@ const TerserPlugin = require("terser-webpack-plugin");
 const config = require("./config");
 const path = require("path");
 const webpack = require("webpack");
-
+const devMode = process.env.NODE_ENV !== "production";
 // Load aliases from config and resolve their full path
 let aliases = {};
 if (config.aliases) {
@@ -61,42 +60,17 @@ var webpackConfig = {
     filename: "js/[name].[chunkhash].js",
     chunkFilename: "js/[id].[chunkhash].js",
     publicPath: config.build.assetsURL,
+    clean: true,
   },
   optimization: {
+    minimize: true,
     minimizer: [
       new TerserPlugin({
         terserOptions: {
-          parse: {
-            // We want terser to parse ecma 8 code. However, we don't want it
-            // to apply any minification steps that turns valid ecma 5 code
-            // into invalid ecma 5 code. This is why the 'compress' and 'output'
-            // sections only apply transformations that are ecma 5 safe
-            // https://github.com/facebook/create-react-app/pull/4234
-            ecma: 8,
-          },
-          compress: {
-            ecma: 5,
-            warnings: false,
-            // Disabled because of an issue with Uglify breaking seemingly valid code:
-            // https://github.com/facebook/create-react-app/issues/2376
-            // Pending further investigation:
-            // https://github.com/mishoo/UglifyJS2/issues/2011
-            comparisons: false,
-            // Disabled because of an issue with Terser breaking valid code:
-            // https://github.com/facebook/create-react-app/issues/5250
-            // Pending further investigation:
-            // https://github.com/terser-js/terser/issues/120
-            inline: 2,
-          },
-          mangle: {
-            safari10: true,
-          },
+          compress: true,
+          mangle: true,
           output: {
-            ecma: 5,
             comments: false,
-            // Turned on because emoji and regex is not minified properly using default
-            // https://github.com/facebook/create-react-app/issues/2488
-            ascii_only: true,
           },
         },
       }),
@@ -189,8 +163,7 @@ var webpackConfig = {
       },
     ],
   },
-  devtool:
-    process.env.NODE_ENV === "production" ? "source-map" : "inline-source-map",
+  devtool: devMode ? "inline-source-map" : "source-map",
   plugins: [
     new ESLintPlugin({
       emitWarning: true,
@@ -207,13 +180,6 @@ var webpackConfig = {
       // both options are optional
       filename: "css/[name].[contenthash].css",
       chunkFilename: "css/[name].[contenthash].css",
-    }),
-    // Removes the dist folder before each run.
-    new CleanWebpackPlugin({
-      dry: false,
-      verbose: false,
-      dangerouslyAllowCleanPatternsOutsideProject: true,
-      cleanStaleWebpackAssets: process.env.NODE_ENV === "production",   // keep stale assets in dev because of OS issues
     }),
     // Copying relevant CSS files as TinyMCE tries to import css files from the dist/js folder of static files
     new CopyWebpackPlugin({
@@ -250,9 +216,10 @@ var webpackConfig = {
   snapshot: {
     managedPaths: [],
   },
+  watch: devMode,
   watchOptions: {
     followSymlinks: true,
-  },
+    },
   cache: false,
 };
 
@@ -262,9 +229,5 @@ if (process.env.npm_config_report) {
   webpackConfig.plugins.push(new BundleAnalyzerPlugin());
 }
 
-if (process.env.NODE_ENV === "development") {
-  const LiveReloadPlugin = require("webpack-livereload-plugin");
-  webpackConfig.plugins.push(new LiveReloadPlugin());
-}
 
 module.exports = webpackConfig;

--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -31,7 +31,6 @@
     "autoprefixer": "^10.4.0",
     "babel-loader": "^9.0.0",
     "chalk": "^5.0.0",
-    "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.0.0",
     "css-minimizer-webpack-plugin": "^4.2.0",
     "eslint-config-react-app": "^7.0.1",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
This PR:
- Closes [#2557](https://github.com/inveniosoftware/invenio-app-rdm/issues/2557)


### Question
While debugging, I found that `CleanWebpackPlugin` plugin, becomes redundant after upgrading to webpack V5
https://github.com/inveniosoftware/invenio-assets/blob/f56291451352292bba876dcca0f27b97500279dd/invenio_assets/assets/build/webpack.config.js#L210-L216
by adding `clean: true` to [ `output`](https://github.com/inveniosoftware/invenio-assets/blob/f56291451352292bba876dcca0f27b97500279dd/invenio_assets/assets/build/webpack.config.js#L58), see [cleaning-up-the-dist-folder](https://webpack.js.org/guides/output-management/#cleaning-up-the-dist-folder)
Did I overlooked another purpose for the CleanWebpackPlugin? 🤔



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
