### PR TITLE
fix: resolve dependency warning

### DIFF
--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -22,6 +22,7 @@
     "ajv": "^8.12.0",
     "@babel/eslint-parser": "^7.18.0",
     "@babel/plugin-proposal-class-properties": "^7.18.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
     "@babel/plugin-transform-runtime": "^7.18.0",
     "@babel/preset-env": "^7.18.0",
     "@babel/preset-react": "^7.18.0",


### PR DESCRIPTION
* adding this dependency is proposed in the dependency warning:

  One of your dependencies, babel-preset-react-app, is importing the
  "@babel/plugin-proposal-private-property-in-object" package without
  declaring it in its dependencies. This is currently working because
  "@babel/plugin-proposal-private-property-in-object" is already in your
  node_modules folder for unrelated reasons, but it may break at any time.

  babel-preset-react-app is part of the create-react-app project, which
  is not maintianed anymore. It is thus unlikely that this bug will
  ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
  your devDependencies to work around this error. This will make this message
  go away.
