### PR TITLE
fix: ERROR in Failed to load plugin 'jsx-a11y'

### DIFF
--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -13,6 +13,7 @@
     "tinymce": "^6.7.2"
   },
   "devDependencies": {
+    "es-abstract": "<1.22.4",
     "browserify-zlib": "^0.2.0",
     "https-browserify": "^1.0.0",
     "stream-browserify": "^3.0.0",


### PR DESCRIPTION
* the problem is that es-abstract released a new version 1.22.4 and this
  created following error message:

  ERROR in Failed to load plugin 'jsx-a11y' declared in
  'js/invenio_administration/.eslintrc.yml »
  @inveniosoftware/eslint-config-invenio':
  unknown record type: function Type(x) {
 	if (typeof x === 'symbol') {
 		return 'Symbol';
 	}
 	if (typeof x === 'bigint') {
 		return 'BigInt';
 	}
 	return ES5Type(x);
  }
