### PR TITLE
webpack: unminimized assets in development mode

### DIFF
--- a/invenio_assets/assets/build/webpack.config.js
+++ b/invenio_assets/assets/build/webpack.config.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2017-2018 CERN.
+ * Copyright (C) 2017-2025 CERN.
  * Copyright (C) 2022-2023 Graz University of Technology.
  * Copyright (C) 2023      TU Wien.
  *
@@ -75,6 +75,10 @@ var webpackConfig = {
     publicPath: config.build.assetsURL,
   },
   optimization: {
+    // Keep unminimized assets in development mode (i.e. `watch` and not `build`)
+    // so that components inspection with the React Developer Tools browser extension
+    // shows full component names.
+    minimize: process.env.NODE_ENV === "production",
     minimizer: [
       new TerserPlugin({
         terserOptions: {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Keep unminimized assets in development mode (i.e. `watch` and not `build`) so that components inspection with the React Developer Tools browser extension shows full component names.

How components inspection currently looks:
![Sceenshot showing minimized component names](https://github.com/user-attachments/assets/f3806fc3-6c28-4a87-8253-4031f3f0aa5b)

With this pull request, once watching assets of installed modules, component inspection will look like this:
![Sceenshot showing full component names](https://github.com/user-attachments/assets/f93c4793-62c1-4cda-8ef8-6238eddb54dd)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
