### PR TITLE
setup: pin rspack

### DIFF
--- a/invenio_assets/assets/rspack-package.json
+++ b/invenio_assets/assets/rspack-package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": ">1.0.0",
-    "@rspack/core": ">1.0.0",
+    "@rspack/core": "<1.7.0",
     "@rspack/dev-server": ">1.0.0",
     "@swc/core": "^1.6.13",
     "@swc/helpers": "^0.5.11",


### PR DESCRIPTION
* rspack >=1.7.0 introduced that 'this' in a closure will compile to an
  undefined value. so code which uses a callback and uses something like
  'this.props' in the function body will stop working.

* the code should work as the javascript specs and tests show that the
  code should be correct so rspack introduced a bug with 1.7.0.

* until now pinning to <1.7.0 is the fasted way to fix it.
