### PR TITLE
webpack: fix: set experiments.typescript to false

### DIFF
--- a/invenio_assets/assets/build/webpack.config.js
+++ b/invenio_assets/assets/build/webpack.config.js
@@ -249,6 +249,11 @@ var webpackConfig = {
   watchOptions: {
     followSymlinks: true,
   },
+  // Starting from webpack v5.109.0, `experiments.typescript` defaults to `auto`,
+  // but it is causing ModuleNotFoundError with some modules where a TSConfig file cannot be found.
+  experiments: {
+    typescript: false,
+  },
 };
 
 // Copying relevant CSS files as e.g. TinyMCE tries to import CSS files from the dist/js folder of static files


### PR DESCRIPTION
The latest version of webpack [v5.109.0](https://github.com/webpack/webpack/releases/tag/v5.109.0) introduces the following change:

> Default experiments.typescript to "auto", enabling built-in TypeScript support on Node.js >= 22.6 when no TypeScript loader is registered

More details on this feature in [Webpack 5.109 - Built-in Support Goes "auto"](https://webpack.js.org/blog/2026-07-24-webpack-5-109/#built-in-support-goes-auto).

This is breaking `invenio-cli install` on InvenioRDM instances with errors like:

```
ERROR in ./node_modules/side-channel/index.js 3:17-42
Module not found: Error: ENOENT: no such file or directory, open '/home/user/invenio-rdm/.venv/var/instance/assets/node_modules/side-channel/node_modules/@ljharb/tsconfig/tsconfig.json'
ModuleNotFoundError: Module not found: Error: ENOENT: no such file or directory, open '/home/user/invenio-rdm/.venv/var/instance/assets/node_modules/side-channel/node_modules/@ljharb/tsconfig/tsconfig.json'
```

or:

```
ERROR in ./node_modules/@react-dnd/asap/dist/esm/index.mjs 2:0-28
Module not found: Error: ENOENT: no such file or directory, open '/home/user/invenio-rdm/.venv/var/instance/assets/node_modules/@react-dnd/tsconfig.base.json'
ModuleNotFoundError: Module not found: Error: ENOENT: no such file or directory, open '/home/user/invenio-rdm/.venv/var/instance/assets/node_modules/@react-dnd/tsconfig.base.json'
```

This PR disables this experimental feature to fix the build.