### PR TITLE
setup: upgrade rspack to v2

### DIFF
--- a/invenio_assets/assets/rspack-package.json
+++ b/invenio_assets/assets/rspack-package.json
@@ -10,9 +10,9 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "@rspack/cli": ">1.0.0",
-    "@rspack/core": "<1.7.0",
-    "@rspack/dev-server": ">1.0.0",
+    "@rspack/cli": "^2.0.0",
+    "@rspack/core": "^2.0.0",
+    "@rspack/dev-server": "^2.0.0",
     "@swc/core": "^1.6.13",
     "@swc/helpers": "^0.5.11",
     "sass-loader": "^16.0.0",
@@ -21,7 +21,7 @@
     "@inveniosoftware/eslint-config-invenio": "^2.0.0",
     "autoprefixer": "^10.4.0",
     "babel-loader": "^9.0.0",
-    "css-loader": "^6.0.0",
+    "css-loader": "^7.1.4",
     "eventsource-polyfill": "^0.9.0",
     "expose-loader": "^4.0.0",
     "file-loader": "^6.0.0",


### PR DESCRIPTION
> AI disclosure: Claude Code diagnosed the npm ERESOLVE failure, traced it to the unbounded `@rspack/cli` range against the `<1.7.0` rspack/core pin, found the `css-loader` peer cap. I verified a full rspack v2.x asset build on a local InvenioRDM instance (both with `pnpm` and `npm`. I also verified on a running instance that the two runtime issues reported in #179 no longer occur.

* `@rspack/cli` and `@rspack/dev-server` were unbounded, so they resolved
  to 2.x while `@rspack/core` stayed below 1.7.0. Both declare a peer
  dependency on core `^2`, which npm rejects with ERESOLVE; pnpm installs
  the mismatched pair and only warns.

* `css-loader` has to be bumped to 7.1.4 in the same commit. Earlier
  releases cap its optional `@rspack/core` peer at `0.x || 1.x`, so
  rspack/core 2 is unresolvable.

* this drops the `<1.7.0` pin added for the closure `this` codegen bug.
  Both sites reported at the time were checked at runtime against v2 and
  behave correctly: the `AdminForm` case from invenio-administration and
  the arrow callback in `DepositFilesService.js` in invenio-rdm-records.
