### PR TITLE
fix: deprecation warning from less

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@
 Changes
 =======
 
+Version v4.2.6 (released 2026-08-04)
+
+- fix: deprecation warning from less
+
 Version v4.2.5 (released 2026-07-29)
 
 - setup: upgrade rspack to v2

--- a/invenio_assets/__init__.py
+++ b/invenio_assets/__init__.py
@@ -105,7 +105,7 @@ Additionally if we have some static files we should collect them:
 from .ext import InvenioAssets
 from .proxies import current_assets
 
-__version__ = "4.2.5"
+__version__ = "4.2.6"
 
 __all__ = (
     "__version__",

--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -37,7 +37,7 @@
     "eventsource-polyfill": "^0.9.0",
     "expose-loader": "^4.0.0",
     "file-loader": "^6.0.0",
-    "less": "^4.0.0",
+    "less": "<4.8.0",
     "less-loader": "^11.0.0",
     "ora": "^6.0.0",
     "patch-package": "^6.5.0",

--- a/invenio_assets/assets/package.json
+++ b/invenio_assets/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invenio-assets",
-  "version": "2.0.0",
+  "version": "4.2.6",
   "description": "Invenio assets",
   "author": "CERN <info@inveniosoftware.org>",
   "private": true,

--- a/invenio_assets/assets/rspack-package.json
+++ b/invenio_assets/assets/rspack-package.json
@@ -25,7 +25,7 @@
     "eventsource-polyfill": "^0.9.0",
     "expose-loader": "^4.0.0",
     "file-loader": "^6.0.0",
-    "less": "^4.0.0",
+    "less": "<4.8.0",
     "less-loader": "^11.0.0",
     "ora": "^6.0.0",
     "patch-package": "^6.5.0",

--- a/invenio_assets/assets/rspack-package.json
+++ b/invenio_assets/assets/rspack-package.json
@@ -1,6 +1,6 @@
 {
   "name": "invenio-assets",
-  "version": "2.0.0",
+  "version": "4.2.6",
   "description": "Invenio assets",
   "author": "CERN <info@inveniosoftware.org>",
   "private": true,


### PR DESCRIPTION
* Variable names beginning with a number are deprecated and will be
  removed in Less 5.x. Rename the variable to start with a valid
  identifier character

* semantic-ui-less/themes/default/collections/menu.variables
  on line 444, column 9:
  <w> 444 @small: @13px;
